### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ deploy:
   provider: pages
   skip_cleanup: true
   github_token: $GITHUB_TOKEN
-  local_dir: ${TRAVIS_BUILD_DIR}/output_prod
+  local_dir:  ${TRAVIS_BUILD_DIR}/output_prod
   repo: LyseonTech/lyseontech.github.io
   target_branch: master
   email: travis-ci@lyseon.tech


### PR DESCRIPTION
Build está quebrando porque aparentemente está faltando um espaço no rsync:

```
rsync: change_dir "/home/travis/build/LyseonTech/site/home/travis/build/LyseonTech/site/output_prod" failed: No such file or directory (2)
```

Porém esta rotina de rsync é do próprio Travis.

Este commit coloca um espaço a mais para testar se será incluído um espaço entre origem e destino do rsync.

https://travis-ci.org/LyseonTech/site/builds/327917642